### PR TITLE
Espurna fixes + backports

### DIFF
--- a/src/NTPClientLib.cpp
+++ b/src/NTPClientLib.cpp
@@ -212,14 +212,18 @@ bool NTPClient::begin (String ntpServerName, int8_t timeZone, bool daylight, int
         DEBUGLOG ("Time sync not started\r\n");
         return false;
     }
-    if (udp_conn)
+
+    if (udp_conn) {
         udp = udp_conn;
-    else
+    }
+
+    if (!udp) {
 #if NETWORK_TYPE == NETWORK_W5100
         udp = new EthernetUDP ();
 #else
         udp = new WiFiUDP ();
 #endif
+    }
 
     //_timeZone = timeZone;
     setDayLight (daylight);

--- a/src/NtpClientLib.h
+++ b/src/NtpClientLib.h
@@ -391,9 +391,9 @@ public:
 protected:
 
 #if NETWORK_TYPE == NETWORK_W5100
-    EthernetUDP *udp;
+    EthernetUDP *udp = nullptr;
 #elif NETWORK_TYPE == NETWORK_ESP8266 || NETWORK_TYPE == NETWORK_WIFI101 || NETWORK_TYPE == NETWORK_ESP32
-    WiFiUDP *udp;
+    WiFiUDP *udp = nullptr;
 #endif
     bool _daylight;             ///< Does this time zone have daylight saving?
     int8_t _timeZone = 0;       ///< Keep track of set time zone offset

--- a/src/NtpClientLib.h
+++ b/src/NtpClientLib.h
@@ -440,7 +440,7 @@ public:
     * @param[in] Pointer to message buffer.
     * @param[out] Decoded time from message, 0 if error ocurred.
     */
-    time_t decodeNtpMessage (char *messageBuffer);
+    time_t decodeNtpMessage (uint8_t *messageBuffer);
 
     /**
     * Set last successful synchronization time.


### PR DESCRIPTION
- Check if received timestamp is 0 before converting it to unix ts. Rare case when NTP server hates us, because we are sending too much requests / broken / unsynchronized / does not return correct data / (?) wifiudp returns bad data e.g. ntp timestamp is zero and -70y results in overflow:
```python3
>>> datetime.datetime.fromtimestamp((2 ** 32) - 2208988800)
datetime.datetime(2036, 2, 7, 9, 28, 16)
```
- Additional check for stratum value (per https://tools.ietf.org/html/rfc5905#page-20)
- Do not recreate WiFiUDP instance when calling .begin()
- Minor typing update: udp.read() returns binary data, not char string

*edit:* 
- New check for receive and reference timestamps, kind-of sanity check for the NTP server

*edit2:*
ezTime checks with slightly shorter bitshift. ezTime itself is not here yet, pending some tweaks to make timezone handling more robust. until then - manually tweaking NtpClient